### PR TITLE
Create SundayDecorator

### DIFF
--- a/SundayDecorator
+++ b/SundayDecorator
@@ -1,0 +1,26 @@
+package com.example.open_calander_junkyu_java3;
+
+import android.graphics.Color;
+import android.text.style.ForegroundColorSpan;
+
+import com.prolificinteractive.materialcalendarview.CalendarDay;
+import com.prolificinteractive.materialcalendarview.DayViewDecorator;
+import com.prolificinteractive.materialcalendarview.DayViewFacade;
+
+import java.util.Calendar;
+
+public class SundayDecorator implements DayViewDecorator
+{
+    private final Calendar calendar = Calendar.getInstance();
+    public SundayDecorator() {    }
+    @Override public boolean shouldDecorate(CalendarDay day)
+    {
+        day.copyTo(calendar);
+        int weekDay = calendar.get(Calendar.DAY_OF_WEEK);
+        return weekDay == Calendar.SUNDAY;
+    }
+    @Override public void decorate(DayViewFacade view)
+    {
+        view.addSpan(new ForegroundColorSpan(Color.RED));
+    }
+}


### PR DESCRIPTION
달력의 일요일에 색깔을 넣어주는 코드입니다. 위의 토요일 코드와 함께 메인 액티비티에 
 calendarView.addDecorators(
                new SundayDecorator(),
                new SaturdayDecorator(),// 주말 색깔 적용,
                new EventDecorator(Color.RED, Collections.singleton(CalendarDay.today()))//오늘일자에 점 찍기
        );

이걸 추가하고 gradle에 
implementation "com.prolificinteractive:material-calendarview:1.4.3"

이걸 추가하면 토요일 일요일의 색깔이 각각 파란색 빨간색으로 변합니다.